### PR TITLE
Add root classes for easier styling

### DIFF
--- a/src/components/Bot.tsx
+++ b/src/components/Bot.tsx
@@ -341,7 +341,7 @@ const FormInputView = (props: {
 
   return (
     <div
-      class="w-full h-full flex flex-col items-center justify-center px-4 py-8 rounded-lg"
+      class="w-full h-full flex flex-col items-center justify-center px-4 py-8 rounded-lg bot-form-root"
       style={{
         'font-family': 'Poppins, sans-serif',
         'font-size': props.fontSize ? `${props.fontSize}px` : '16px',
@@ -1758,7 +1758,9 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       ) : (
         <div
           ref={botContainer}
-          class={'relative flex w-full h-full text-base overflow-hidden bg-cover bg-center flex-col items-center chatbot-container ' + props.class}
+          class={
+            'bot-root relative flex w-full h-full text-base overflow-hidden bg-cover bg-center flex-col items-center chatbot-container ' + props.class
+          }
           onDragEnter={handleDrag}
         >
           {isDragActive() && (

--- a/src/components/FeedbackContentDialog.tsx
+++ b/src/components/FeedbackContentDialog.tsx
@@ -30,7 +30,7 @@ const FeedbackContentDialog = (props: FeedbackContentDialogProps) => {
 
   return (
     <>
-      <div class="flex overflow-x-hidden overflow-y-auto fixed inset-0 z-[1002] outline-none focus:outline-none justify-center items-center">
+      <div class="flex overflow-x-hidden overflow-y-auto fixed inset-0 z-[1002] outline-none focus:outline-none justify-center items-center feedback-dialog-root">
         <div class="relative w-full my-6 max-w-3xl mx-4">
           <div
             class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none"

--- a/src/components/bubbles/AgentReasoningBubble.tsx
+++ b/src/components/bubbles/AgentReasoningBubble.tsx
@@ -81,7 +81,7 @@ export const AgentReasoningBubble = (props: Props) => {
   };
 
   return (
-    <div class="mb-6">
+    <div class="mb-6 agent-bubble-root">
       {props.agentArtifacts && (
         <div class="flex flex-row items-start flex-wrap w-full gap-2">
           <For each={agentReasoningArtifacts(props.agentArtifacts)}>

--- a/src/components/bubbles/BotBubble.tsx
+++ b/src/components/bubbles/BotBubble.tsx
@@ -389,7 +389,7 @@ export const BotBubble = (props: Props) => {
   };
 
   return (
-    <div>
+    <div class="bot-bubble-root">
       <div class="flex flex-row justify-start mb-2 items-start host-container" style={{ 'margin-right': '50px' }}>
         <Show when={props.showAvatar}>
           <Avatar initialAvatarSrc={props.avatarSrc} />

--- a/src/components/bubbles/FollowUpPromptBubble.tsx
+++ b/src/components/bubbles/FollowUpPromptBubble.tsx
@@ -8,7 +8,7 @@ export const FollowUpPromptBubble = (props: Props) => (
     <div
       data-modal-target="defaultModal"
       data-modal-toggle="defaultModal"
-      class="flex justify-start items-start animate-fade-in gap-1 host-container hover:brightness-90 active:brightness-75"
+      class="flex justify-start items-start animate-fade-in gap-1 host-container hover:brightness-90 active:brightness-75 followup-prompt-bubble-root"
       onClick={() => props.onPromptClick?.()}
     >
       <span

--- a/src/components/bubbles/GuestBubble.tsx
+++ b/src/components/bubbles/GuestBubble.tsx
@@ -85,7 +85,7 @@ export const GuestBubble = (props: Props) => {
   };
 
   return (
-    <div class="flex justify-end mb-2 items-end guest-container" style={{ 'margin-left': '50px' }}>
+    <div class="flex justify-end mb-2 items-end guest-container guest-bubble-root" style={{ 'margin-left': '50px' }}>
       <div
         class="max-w-full flex flex-col justify-center items-start chatbot-guest-bubble px-4 py-2 gap-2 mr-2"
         data-testid="guest-bubble"

--- a/src/components/bubbles/LeadCaptureBubble.tsx
+++ b/src/components/bubbles/LeadCaptureBubble.tsx
@@ -82,7 +82,7 @@ export const LeadCaptureBubble = (props: Props) => {
   };
 
   return (
-    <div class="flex flex-row justify-start mb-2 items-start host-container" style={{ 'margin-right': '50px' }}>
+    <div class="flex flex-row justify-start mb-2 items-start host-container leadcapture-bubble-root" style={{ 'margin-right': '50px' }}>
       <Show when={props.showAvatar}>
         <Avatar initialAvatarSrc={props.avatarSrc} />
       </Show>

--- a/src/components/bubbles/LoadingBubble.tsx
+++ b/src/components/bubbles/LoadingBubble.tsx
@@ -1,7 +1,7 @@
 import { TypingBubble } from '@/components';
 
 export const LoadingBubble = () => (
-  <div class="flex justify-start mb-2 items-start animate-fade-in host-container">
+  <div class="flex justify-start mb-2 items-start animate-fade-in host-container loading-bubble-root">
     <span class="px-4 py-4 ml-2 whitespace-pre-wrap max-w-full chatbot-host-bubble" data-testid="host-bubble">
       <TypingBubble />
     </span>

--- a/src/components/bubbles/SourceBubble.tsx
+++ b/src/components/bubbles/SourceBubble.tsx
@@ -8,7 +8,7 @@ export const SourceBubble = (props: Props) => (
     <div
       data-modal-target="defaultModal"
       data-modal-toggle="defaultModal"
-      class="flex justify-start mb-2 items-start animate-fade-in host-container hover:brightness-90 active:brightness-75 source-bubble"
+      class="flex justify-start mb-2 items-start animate-fade-in host-container hover:brightness-90 active:brightness-75 source-bubble source-bubble-root"
       onClick={() => props.onSourceClick?.()}
     >
       <span

--- a/src/components/bubbles/StarterPromptBubble.tsx
+++ b/src/components/bubbles/StarterPromptBubble.tsx
@@ -8,7 +8,7 @@ export const StarterPromptBubble = (props: Props) => (
     <div
       data-modal-target="defaultModal"
       data-modal-toggle="defaultModal"
-      class="flex justify-start items-start animate-fade-in host-container hover:brightness-90 active:brightness-75"
+      class="flex justify-start items-start animate-fade-in host-container hover:brightness-90 active:brightness-75 starter-prompt-bubble-root"
       onClick={() => props.onPromptClick?.()}
     >
       <span

--- a/src/features/bubble/components/Bubble.tsx
+++ b/src/features/bubble/components/Bubble.tsx
@@ -100,7 +100,7 @@ export const Bubble = (props: BubbleProps) => {
           right: `${Math.max(0, Math.min(buttonPosition().right, window.innerWidth - (bubbleProps.theme?.chatWindow?.width ?? 410) - 10))}px`,
         }}
         class={
-          `fixed sm:right-5 rounded-lg w-full sm:w-[400px] max-h-[704px]` +
+          `bubble-root fixed sm:right-5 rounded-lg w-full sm:w-[400px] max-h-[704px]` +
           (isBotOpened() ? ' opacity-1' : ' opacity-0 pointer-events-none') +
           ` bottom-${chatWindowBottom}px`
         }

--- a/src/features/full/components/Full.tsx
+++ b/src/features/full/components/Full.tsx
@@ -51,6 +51,7 @@ export const Full = (props: FullProps, { element }: { element: HTMLElement }) =>
       <style>{styles}</style>
       <Show when={isBotDisplayed()}>
         <div
+          class="full-root"
           style={{
             'background-color': props.theme?.chatWindow?.backgroundColor || '#ffffff',
             height: props.theme?.chatWindow?.height ? `${props.theme?.chatWindow?.height.toString()}px` : '100dvh',

--- a/src/features/popup/components/DisclaimerPopup.tsx
+++ b/src/features/popup/components/DisclaimerPopup.tsx
@@ -46,7 +46,7 @@ export const DisclaimerPopup = (props: DisclaimerPopupProps) => {
   return (
     <Show when={popupProps.isOpen}>
       <div
-        class="fixed inset-0 rounded-lg flex items-center justify-center backdrop-blur-sm z-50"
+        class="fixed inset-0 rounded-lg flex items-center justify-center backdrop-blur-sm z-50 disclaimer-popup-root"
         style={{ background: popupProps.blurredBackgroundColor || 'rgba(0, 0, 0, 0.4)' }}
       >
         <div

--- a/src/features/popup/components/Popup.tsx
+++ b/src/features/popup/components/Popup.tsx
@@ -79,7 +79,14 @@ export const Popup = (props: PopupProps) => {
   return (
     <Show when={isBotOpened()}>
       <style>{styles}</style>
-      <div class="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true" style={{ 'z-index': 1100 }} on:click={closeBot}>
+      <div
+        class="relative z-10 popup-root"
+        aria-labelledby="modal-title"
+        role="dialog"
+        aria-modal="true"
+        style={{ 'z-index': 1100 }}
+        on:click={closeBot}
+      >
         <style>{styles}</style>
         <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity animate-fade-in" />
         <div class="fixed inset-0 z-10 overflow-y-auto">


### PR DESCRIPTION
## Summary
- add root CSS classes to bubble components
- mark root nodes in popup, dialog and full page components
- expose form and bot container roots with new classes

## Testing
- `npx prettier -w ...`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*