### PR TITLE
Updated `rollup-plugin-serve` from `v2.0.2` to `v3.0.0` for compatibility with rollup v3.29.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rollup": "3.29.5",
     "rollup-plugin-livereload": "2.0.5",
     "rollup-plugin-postcss": "4.0.2",
-    "rollup-plugin-serve": "2.0.2",
+    "rollup-plugin-serve": "3.0.0",
     "rollup-plugin-typescript-paths": "1.4.0",
     "tailwindcss": "^3.3.1",
     "typescript": "5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2(postcss@8.5.6)
       rollup-plugin-serve:
-        specifier: 2.0.2
-        version: 2.0.2
+        specifier: 3.0.0
+        version: 3.0.0
       rollup-plugin-typescript-paths:
         specifier: 1.4.0
         version: 1.4.0(typescript@5.0.3)
@@ -2493,8 +2493,8 @@ packages:
     peerDependencies:
       postcss: 8.x
 
-  rollup-plugin-serve@2.0.2:
-    resolution: {integrity: sha512-ALqyTbPhlf7FZ5RzlbDvMYvbKuCHWginJkTo6dMsbgji/a78IbsXox+pC83HENdkTRz8OXrTj+aShp3+3ratpg==}
+  rollup-plugin-serve@3.0.0:
+    resolution: {integrity: sha512-DjVRhbwC0OgP1Q1sj8Lvx12ee60UTZM767kkjT61sYKHw/wLpANAw3VZN5ZMa5NlvO8bYpfTaqiUrW+icAjXFg==}
 
   rollup-plugin-typescript-paths@1.4.0:
     resolution: {integrity: sha512-6EgeLRjTVmymftEyCuYu91XzY5XMB5lR0YrJkeT0D7OG2RGSdbNL+C/hfPIdc/sjMa9Sl5NLsxIr6C/+/5EUpA==}
@@ -5520,7 +5520,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  rollup-plugin-serve@2.0.2:
+  rollup-plugin-serve@3.0.0:
     dependencies:
       mime: 4.0.7
       opener: 1.5.2

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,18 +41,19 @@ const indexConfig = {
     typescript(),
     typescriptPaths({ preserveExtensions: true }),
     terser({ output: { comments: false } }),
-    ...(isDev
-      ? [
-          serve({
-            open: true,
-            verbose: true,
-            contentBase: ['dist', 'public'],
-            host: 'localhost',
-            port: 5678,
-          }),
-          livereload({ watch: 'dist' }),
-        ]
-      : []), // Add serve/livereload only in development
+    // Temporarily disabled due to compatibility issue
+    // ...(isDev
+    //   ? [
+    //       serve({
+    //         open: true,
+    //         verbose: true,
+    //         contentBase: ['dist', 'public'],
+    //         host: 'localhost',
+    //         port: 5678,
+    //       }),
+    //       livereload({ watch: 'dist' }),
+    //     ]
+    //   : []), // Add serve/livereload only in development
   ],
 };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,19 +41,18 @@ const indexConfig = {
     typescript(),
     typescriptPaths({ preserveExtensions: true }),
     terser({ output: { comments: false } }),
-    // Temporarily disabled due to compatibility issue
-    // ...(isDev
-    //   ? [
-    //       serve({
-    //         open: true,
-    //         verbose: true,
-    //         contentBase: ['dist', 'public'],
-    //         host: 'localhost',
-    //         port: 5678,
-    //       }),
-    //       livereload({ watch: 'dist' }),
-    //     ]
-    //   : []), // Add serve/livereload only in development
+    ...(isDev
+      ? [
+          serve({
+            open: true,
+            verbose: true,
+            contentBase: ['dist', 'public'],
+            host: 'localhost',
+            port: 5678,
+          }),
+          livereload({ watch: 'dist' }),
+        ]
+      : []), // Add serve/livereload only in development
   ],
 };
 


### PR DESCRIPTION

### **Solution**
Updated `rollup-plugin-serve` from `v2.0.2` to `v3.0.0` for compatibility with rollup v3.29.5.

### **Changes**
- Updated `rollup-plugin-serve` dependency to `^3.0.0`
- Restored development server functionality on `localhost:5678`
- Fixed build compatibility issues

### **Impact**
- ✅ **Development server works** on `localhost:5678`
- ✅ **No more compatibility errors**
- ✅ **All functionality preserved**

---

## ⚠️ **IMPORTANT: After Merging This PR**

**You MUST update the reference in the main repository PR** (`ct/fixing-prisma-version-compatibility`) to point to the new embed package version that includes this fix.

### **Steps to Update Main PR:**
1. After this PR is merged, update the embed package reference in the main repository
2. Update the commit hash or version reference in the main PR
3. Ensure the main PR description reflects that the embed compatibility issue is resolved

### **Why This Matters:**
The main PR currently includes a temporary fix for the embed package. Once this PR is merged, the main PR should reference the proper embed package version that includes this permanent fix.

---

**Related PR:** `ct/fixing-prisma-version-compatibility` (main repository)