### PR TITLE
fix(AGENT-661): prevent arrow keys from clearing draft message with cursor boundary detection

### DIFF
--- a/src/components/inputs/textInput/components/TextInput.tsx
+++ b/src/components/inputs/textInput/components/TextInput.tsx
@@ -92,12 +92,16 @@ export const TextInput = (props: TextInputProps) => {
       }
     } else if (props.enableInputHistory) {
       if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        const previousInput = inputHistory().getPreviousInput(props.inputValue);
-        props.onInputChange(previousInput);
+        const cursorPosition = inputRef?.selectionStart ?? 0;
+        if (cursorPosition === 0) {
+          e.preventDefault();
+          const previousInput = inputHistory().getPreviousInput(props.inputValue);
+          props.onInputChange(previousInput);
+        }
       } else if (e.key === 'ArrowDown') {
-        // Only navigate forward if already in history mode (after ArrowUp)
-        if (inputHistory().getCurrentIndex() > -1) {
+        const cursorPosition = inputRef?.selectionStart ?? 0;
+        const textLength = props.inputValue.length;
+        if (cursorPosition === textLength && inputHistory().getCurrentIndex() > -1) {
           e.preventDefault();
           const nextInput = inputHistory().getNextInput();
           props.onInputChange(nextInput);

--- a/src/components/inputs/textInput/components/TextInput.tsx
+++ b/src/components/inputs/textInput/components/TextInput.tsx
@@ -96,9 +96,12 @@ export const TextInput = (props: TextInputProps) => {
         const previousInput = inputHistory().getPreviousInput(props.inputValue);
         props.onInputChange(previousInput);
       } else if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        const nextInput = inputHistory().getNextInput();
-        props.onInputChange(nextInput);
+        // Only navigate forward if already in history mode (after ArrowUp)
+        if (inputHistory().getCurrentIndex() > -1) {
+          e.preventDefault();
+          const nextInput = inputHistory().getNextInput();
+          props.onInputChange(nextInput);
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
Fixes a bug where pressing the ArrowDown key in the chat input would clear the user's draft message when they hadn't navigated through history first.

## Root Cause
`getNextInput()` returns empty `tempInput` when `currentIndex === -1` (not in history mode), causing the input to be cleared unexpectedly.

## Changes
- Modified `src/components/inputs/textInput/components/TextInput.tsx`
- Added cursor boundary detection for both ArrowUp and ArrowDown keys
- **ArrowUp**: Only triggers history navigation when cursor is at position 0 (start of input)
- **ArrowDown**: Only triggers history navigation when cursor is at end of text AND user is already in history mode (`getCurrentIndex() > -1`)
- Moved `e.preventDefault()` inside the guards to allow normal cursor behavior when not navigating history

## Impact
- Users can now press ArrowDown without losing their draft message
- ArrowUp/ArrowDown allow normal cursor movement within multi-line text
- History navigation works correctly after ArrowUp is pressed first
- No breaking changes to existing functionality

## Test Plan
- [ ] Type "Hello" → Press ArrowDown → Message stays "Hello" (not cleared)
- [ ] Type "Draft" → ArrowUp (shows history) → ArrowDown → Returns to "Draft"
- [ ] Type "Test" → Press ArrowDown multiple times → Message stays "Test"
- [ ] Empty input → ArrowDown → No crash, stays empty
- [ ] Multi-line text → ArrowUp in middle of text → Cursor moves up (not history)
- [ ] Multi-line text → ArrowDown in middle of text → Cursor moves down (not history)

🤖 Generated with [Claude Code](https://claude.ai/code)