### PR TITLE
fix(AGENT-675): add sessionStorage for multi-tab chat isolation

### DIFF
--- a/src/components/Bot.tsx
+++ b/src/components/Bot.tsx
@@ -799,7 +799,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   };
 
   const fetchResponseFromEventStream = async (chatflowid: string, params: any) => {
-    const chatId = params.chatId;
+    const requestChatId = params.chatId;
     const input = params.question;
     params.streaming = true;
     console.log('[fetchResponseFromEventStream]', { botProps, params, chatflowid, props });
@@ -879,8 +879,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             closeResponse();
             break;
           case 'end':
-            setSessionStorageChatflow(chatflowid, chatId);
-            setLocalStorageChatflow(chatflowid, chatId);
+            setSessionStorageChatflow(chatflowid, chatId() || requestChatId);
+            setLocalStorageChatflow(chatflowid, chatId() || requestChatId);
             closeResponse();
             break;
         }
@@ -1298,18 +1298,16 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     }
 
     const sessionMessage = getSessionStorageChatflow(props.chatflowid);
-    const chatMessage = Object.keys(sessionMessage).length ? sessionMessage : getLocalStorageChatflow(props.chatflowid);
+    const localStorageMessage = getLocalStorageChatflow(props.chatflowid);
+    const chatMessage = Object.keys(sessionMessage).length ? sessionMessage : localStorageMessage;
     const customerId = (props.chatflowConfig?.vars as any)?.customerId;
 
     // Initialize chatId from localStorage or generate new one
-    if (chatMessage?.chatId) {
-      setChatId(chatMessage.chatId);
-    } else {
-      setChatId(customerId ? `${customerId.toString()}+${uuidv4()}` : uuidv4());
-    }
+    const initialChatId = chatMessage?.chatId || (customerId ? `${customerId.toString()}+${uuidv4()}` : uuidv4());
+    setChatId(initialChatId);
 
     if (chatMessage && Object.keys(chatMessage).length) {
-      const savedLead = chatMessage.lead || getLocalStorageChatflow(props.chatflowid)?.lead;
+      const savedLead = chatMessage.lead || localStorageMessage?.lead;
       if (savedLead) {
         setIsLeadSaved(!!savedLead);
         setLeadEmail(savedLead.email);
@@ -1345,8 +1343,11 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       setMessages([...filteredMessages]);
 
       // Seed sessionStorage if we loaded from localStorage (returning user in new tab)
-      if (!Object.keys(sessionMessage).length && chatMessage?.chatHistory?.length) {
-        setSessionStorageChatflow(props.chatflowid, chatId(), { chatHistory: chatMessage.chatHistory });
+      if (!Object.keys(sessionMessage).length && (chatMessage?.chatHistory?.length || savedLead)) {
+        setSessionStorageChatflow(props.chatflowid, initialChatId, {
+          ...(chatMessage?.chatHistory?.length ? { chatHistory: chatMessage.chatHistory } : {}),
+          ...(savedLead ? { lead: savedLead } : {}),
+        });
       }
     }
 

--- a/src/components/Bot.tsx
+++ b/src/components/Bot.tsx
@@ -32,7 +32,16 @@ import { CircleDotIcon, SparklesIcon, TrashIcon } from './icons';
 import { CancelButton } from './buttons/CancelButton';
 import { cancelAudioRecording, startAudioRecording, stopAudioRecording } from '@/utils/audioRecording';
 import { LeadCaptureBubble } from '@/components/bubbles/LeadCaptureBubble';
-import { removeLocalStorageChatHistory, getLocalStorageChatflow, setLocalStorageChatflow, setCookie, getCookie } from '@/utils';
+import {
+  removeLocalStorageChatHistory,
+  removeSessionStorageChatHistory,
+  getLocalStorageChatflow,
+  getSessionStorageChatflow,
+  setLocalStorageChatflow,
+  setSessionStorageChatflow,
+  setCookie,
+  getCookie,
+} from '@/utils';
 import { cloneDeep, merge } from 'lodash';
 import { FollowUpPromptBubble } from '@/components/bubbles/FollowUpPromptBubble';
 import { fetchEventSource, EventStreamContentType } from '@microsoft/fetch-event-source';
@@ -572,6 +581,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       }
       return item;
     });
+    setSessionStorageChatflow(props.chatflowid, chatId(), { chatHistory: messages });
     setLocalStorageChatflow(props.chatflowid, chatId(), { chatHistory: messages });
   };
 
@@ -869,6 +879,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
             closeResponse();
             break;
           case 'end':
+            setSessionStorageChatflow(chatflowid, chatId);
             setLocalStorageChatflow(chatflowid, chatId);
             closeResponse();
             break;
@@ -1210,6 +1221,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
   const clearChat = () => {
     try {
+      removeSessionStorageChatHistory(props.chatflowid);
       removeLocalStorageChatHistory(props.chatflowid);
       setChatId(
         (props.chatflowConfig?.vars as any)?.customerId ? `${(props.chatflowConfig?.vars as any).customerId.toString()}+${uuidv4()}` : uuidv4(),
@@ -1285,7 +1297,8 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
       setDisclaimerPopupOpen(false);
     }
 
-    const chatMessage = getLocalStorageChatflow(props.chatflowid);
+    const sessionMessage = getSessionStorageChatflow(props.chatflowid);
+    const chatMessage = Object.keys(sessionMessage).length ? sessionMessage : getLocalStorageChatflow(props.chatflowid);
     const customerId = (props.chatflowConfig?.vars as any)?.customerId;
 
     // Initialize chatId from localStorage or generate new one
@@ -1296,7 +1309,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
     }
 
     if (chatMessage && Object.keys(chatMessage).length) {
-      const savedLead = chatMessage.lead;
+      const savedLead = chatMessage.lead || getLocalStorageChatflow(props.chatflowid)?.lead;
       if (savedLead) {
         setIsLeadSaved(!!savedLead);
         setLeadEmail(savedLead.email);
@@ -1330,6 +1343,11 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
 
       const filteredMessages = loadedMessages.filter((message) => message.type !== 'leadCaptureMessage');
       setMessages([...filteredMessages]);
+
+      // Seed sessionStorage if we loaded from localStorage (returning user in new tab)
+      if (!Object.keys(sessionMessage).length && chatMessage?.chatHistory?.length) {
+        setSessionStorageChatflow(props.chatflowid, chatId(), { chatHistory: chatMessage.chatHistory });
+      }
     }
 
     // Determine if particular chatflow is available for streaming

--- a/src/components/bubbles/BotBubble.tsx
+++ b/src/components/bubbles/BotBubble.tsx
@@ -182,7 +182,7 @@ export const BotBubble = (props: Props) => {
   };
 
   const saveToLocalStorage = (rating: FeedbackRatingType) => {
-    const chatDetails = sessionStorage.getItem(`${props.chatflowid}_EXTERNAL`);
+    const chatDetails = sessionStorage.getItem(`${props.chatflowid}_EXTERNAL`) || localStorage.getItem(`${props.chatflowid}_EXTERNAL`);
     if (!chatDetails) return;
     try {
       const parsedDetails = JSON.parse(chatDetails);

--- a/src/components/bubbles/BotBubble.tsx
+++ b/src/components/bubbles/BotBubble.tsx
@@ -182,7 +182,7 @@ export const BotBubble = (props: Props) => {
   };
 
   const saveToLocalStorage = (rating: FeedbackRatingType) => {
-    const chatDetails = localStorage.getItem(`${props.chatflowid}_EXTERNAL`);
+    const chatDetails = sessionStorage.getItem(`${props.chatflowid}_EXTERNAL`);
     if (!chatDetails) return;
     try {
       const parsedDetails = JSON.parse(chatDetails);
@@ -190,7 +190,9 @@ export const BotBubble = (props: Props) => {
       const message = messages.find((msg) => msg.messageId === props.message.messageId);
       if (!message) return;
       message.rating = rating;
-      localStorage.setItem(`${props.chatflowid}_EXTERNAL`, JSON.stringify({ ...parsedDetails, chatHistory: messages }));
+      const updated = JSON.stringify({ ...parsedDetails, chatHistory: messages });
+      sessionStorage.setItem(`${props.chatflowid}_EXTERNAL`, updated);
+      localStorage.setItem(`${props.chatflowid}_EXTERNAL`, updated);
     } catch (e) {
       return;
     }

--- a/src/components/bubbles/LeadCaptureBubble.tsx
+++ b/src/components/bubbles/LeadCaptureBubble.tsx
@@ -4,7 +4,7 @@ import { FormEvent, LeadsConfig, MessageType } from '@/components/Bot';
 import { addLeadQuery, LeadCaptureInput } from '@/queries/sendMessageQuery';
 import { SaveLeadButton } from '@/components/buttons/LeadCaptureButtons';
 import { Avatar } from '@/components/avatars/Avatar';
-import { getLocalStorageChatflow, setLocalStorageChatflow } from '@/utils';
+import { getLocalStorageChatflow, setLocalStorageChatflow, setSessionStorageChatflow } from '@/utils';
 
 type Props = {
   message: MessageType;
@@ -65,13 +65,15 @@ export const LeadCaptureBubble = (props: Props) => {
       });
 
       if (result.data) {
-        setLocalStorageChatflow(props.chatflowid, props.chatId, {
+        const leadData = {
           lead: {
             name: leadName(),
             email: leadEmail(),
             phone: leadPhone(),
           },
-        });
+        };
+        setSessionStorageChatflow(props.chatflowid, props.chatId, leadData);
+        setLocalStorageChatflow(props.chatflowid, props.chatId, leadData);
         props.setIsLeadSaved(true);
         props.setLeadEmail(leadEmail());
       }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -136,8 +136,6 @@ export const setSessionStorageChatflow = (chatflowid: string, chatId: string, sa
       const parsedChatDetails = JSON.parse(chatDetails);
       sessionStorage.setItem(`${chatflowid}_EXTERNAL`, JSON.stringify({ ...parsedChatDetails, ...obj }));
     } catch (e) {
-      const chatId = chatDetails;
-      obj.chatId = chatId;
       sessionStorage.setItem(`${chatflowid}_EXTERNAL`, JSON.stringify(obj));
     }
   }
@@ -154,7 +152,21 @@ export const getSessionStorageChatflow = (chatflowid: string) => {
 };
 
 export const removeSessionStorageChatHistory = (chatflowid: string) => {
-  sessionStorage.removeItem(`${chatflowid}_EXTERNAL`);
+  const chatDetails = sessionStorage.getItem(`${chatflowid}_EXTERNAL`);
+  if (!chatDetails) return;
+  try {
+    const parsedChatDetails = JSON.parse(chatDetails);
+    if (parsedChatDetails.lead) {
+      // Dont remove lead when chat is cleared
+      const obj = { lead: parsedChatDetails.lead };
+      sessionStorage.removeItem(`${chatflowid}_EXTERNAL`);
+      sessionStorage.setItem(`${chatflowid}_EXTERNAL`, JSON.stringify(obj));
+    } else {
+      sessionStorage.removeItem(`${chatflowid}_EXTERNAL`);
+    }
+  } catch (e) {
+    return;
+  }
 };
 
 export const getBubbleButtonSize = (size: 'small' | 'medium' | 'large' | number | undefined) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -124,6 +124,39 @@ export const removeLocalStorageChatHistory = (chatflowid: string) => {
   }
 };
 
+export const setSessionStorageChatflow = (chatflowid: string, chatId: string, saveObj: Record<string, any> = {}) => {
+  const chatDetails = sessionStorage.getItem(`${chatflowid}_EXTERNAL`);
+  const obj = { ...saveObj };
+  if (chatId) obj.chatId = chatId;
+
+  if (!chatDetails) {
+    sessionStorage.setItem(`${chatflowid}_EXTERNAL`, JSON.stringify(obj));
+  } else {
+    try {
+      const parsedChatDetails = JSON.parse(chatDetails);
+      sessionStorage.setItem(`${chatflowid}_EXTERNAL`, JSON.stringify({ ...parsedChatDetails, ...obj }));
+    } catch (e) {
+      const chatId = chatDetails;
+      obj.chatId = chatId;
+      sessionStorage.setItem(`${chatflowid}_EXTERNAL`, JSON.stringify(obj));
+    }
+  }
+};
+
+export const getSessionStorageChatflow = (chatflowid: string) => {
+  const chatDetails = sessionStorage.getItem(`${chatflowid}_EXTERNAL`);
+  if (!chatDetails) return {};
+  try {
+    return JSON.parse(chatDetails);
+  } catch (e) {
+    return {};
+  }
+};
+
+export const removeSessionStorageChatHistory = (chatflowid: string) => {
+  sessionStorage.removeItem(`${chatflowid}_EXTERNAL`);
+};
+
 export const getBubbleButtonSize = (size: 'small' | 'medium' | 'large' | number | undefined) => {
   if (!size) return 48;
   if (typeof size === 'number') return size;


### PR DESCRIPTION
## Summary
Implements AGENT-675 by making chat state tab-scoped with `sessionStorage` as the primary store, while keeping `localStorage` for compatibility/migration.

## Why this change
Users with multiple tabs were sharing the same `localStorage` key, which caused state collisions (for example, feedback and chat history crossing between tabs). This PR isolates active tab state to eliminate cross-tab contamination while preserving existing persisted behavior.

## What changed
### 1) `src/components/Bot.tsx`
- Uses `sessionStorage` as the primary source for active-tab chat state.
- Falls back to `localStorage` when session data is missing (returning users/new tab).
- Seeds session storage from local storage when needed.
- Writes chat history to both stores during message updates and stream end.
- Clears both stores on chat reset (`removeSessionStorageChatHistory` + `removeLocalStorageChatHistory`).

### 2) `src/components/bubbles/BotBubble.tsx`
- Rating updates now write to both session and local storage to keep state consistent.

### 3) `src/components/bubbles/LeadCaptureBubble.tsx`
- Lead capture now writes to both session and local storage.

### 4) `src/utils/index.ts`
- Added session storage helpers:
  - `setSessionStorageChatflow`
  - `getSessionStorageChatflow`
  - `removeSessionStorageChatHistory`
- Included two safety fixes:
  - Removed incorrect fallback behavior in session storage catch path.
  - Preserved `lead` data when clearing session chat history (parity with local storage behavior).

## Behavior after this PR
- **New independent tabs:** isolated active chat state (no cross-tab leaks).
- **Returning user / reload:** previous data still recoverable via local storage fallback.
- **Clear chat:** chat history is cleared but lead data remains preserved.

## Notes
- This PR intentionally addresses tab isolation for normal multi-tab usage.
- Duplicate-tab browser behavior (which can clone session state depending on browser) is out of scope for this ticket.

## Linear
Resolves AGENT-675